### PR TITLE
[削除]詳細ページ戻るボタン

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -5,11 +5,11 @@ class AnswersController < ApplicationController
     @answer = Answer.new(answer_params)
     @answer.user_id = current_user.id
     @answer.question_id = @question.id
-    if @answer.save
-      redirect_to question_path(@question)
-    else
-      render 'questions/show'
-    end
+     if @answer.save
+       redirect_to question_path(@question)
+     else
+       render 'questions/show'
+     end
   end
 
   def destroy

--- a/app/views/questions/_resolved.html.erb
+++ b/app/views/questions/_resolved.html.erb
@@ -1,9 +1,8 @@
 <% if question.is_resolved %>
-    <div>
-     　<%= link_to "解決済★", destroy_resolved_question_path(question), method: :delete,remote: true,class:"is_resolved" %>
+    <div><%= link_to "解決済★", destroy_resolved_question_path(question), method: :delete,remote: true,class:"is_resolved" %>
      </div>
     <% else %>
     <div>
-     　<%= link_to"未解決☆", make_resolved_question_path(question), method: :post, remote: true, class:"is_resolved"  %>
+     <%= link_to"未解決☆", make_resolved_question_path(question), method: :post, remote: true, class:"is_resolved"  %>
     </div>
   <% end %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -20,7 +20,7 @@
   <% end %>
 
   <div class="question_<%= @question.id %>">
-　  <%= render "questions/resolved", question: @question %>
+<%= render "questions/resolved", question: @question %>
   </div>
 
 <div class="comments">
@@ -36,7 +36,7 @@
   <% end %>
 
   <div class="answer_<%= answer.id %>">
-　<%= render "likes/like", question: @question ,answer: answer, like: answer.likes.first %>
+<%= render "likes/like", question: @question ,answer: answer, like: answer.likes.first %>
   </div>
 
 <% end %>
@@ -58,4 +58,3 @@
 </div>
 
 
- <%= link_to '戻る', :back %>


### PR DESCRIPTION
コメント投稿後に質問詳細ページにredirectされる為、その後に:backで前ページへ戻れなかった。全質問一覧へのパスをリンク指定することも出来るが、質問履歴やジャンル検索をした質問一覧に戻りたい場合もある為、戻るボタンは削除した。（ブラウザの戻るボタンで前ページへの移動は容易）